### PR TITLE
Improve "Armature|" Prefix removal

### DIFF
--- a/blender_2_93_X/io_scene_fbx_custom/export_fbx_bin.py
+++ b/blender_2_93_X/io_scene_fbx_custom/export_fbx_bin.py
@@ -2069,10 +2069,12 @@ def fbx_animations(scene_data):
             # [Alessandro] Remove 'Armature|' animation name...
             if scene_data.settings.remove_ghost_armature_root_node_from_export:
                 _astack_key, astack, _alayer_key, _name, _fstart, _fend = anim
-
+                # [Choccy] The original function only worked when the armature name is Armature.
+                # I change it a bit so it removed words before '|' and the '|' as well.
                 _name = _name.decode("utf-8")
-                if _name.startswith("Armature|"):
-                    _name = _name[9:]
+                if _name.__contains__("|"):
+                    indexed = _name.find("|")
+                    _name = _name[indexed+1:]
                 _name = _name.encode("utf-8")
 
                 animations.append((_astack_key, astack, _alayer_key, _name, _fstart, _fend))

--- a/blender_3_0_X/io_scene_fbx_custom/export_fbx_bin.py
+++ b/blender_3_0_X/io_scene_fbx_custom/export_fbx_bin.py
@@ -2071,10 +2071,12 @@ def fbx_animations(scene_data):
             # [Alessandro] Remove 'Armature|' animation name...
             if scene_data.settings.remove_ghost_armature_root_node_from_export:
                 _astack_key, astack, _alayer_key, _name, _fstart, _fend = anim
-
+                # [Choccy] The original function only worked when the armature name is Armature.
+                # I change it a bit so it removed words before '|' and the '|' as well.
                 _name = _name.decode("utf-8")
-                if _name.startswith("Armature|"):
-                    _name = _name[9:]
+                if _name.__contains__("|"):
+                    indexed = _name.find("|")
+                    _name = _name[indexed+1:]
                 _name = _name.encode("utf-8")
 
                 animations.append((_astack_key, astack, _alayer_key, _name, _fstart, _fend))

--- a/blender_3_1_X/io_scene_fbx_custom/export_fbx_bin.py
+++ b/blender_3_1_X/io_scene_fbx_custom/export_fbx_bin.py
@@ -2071,10 +2071,12 @@ def fbx_animations(scene_data):
             # [Alessandro] Remove 'Armature|' animation name...
             if scene_data.settings.remove_ghost_armature_root_node_from_export:
                 _astack_key, astack, _alayer_key, _name, _fstart, _fend = anim
-
+                # [Choccy] The original function only worked when the armature name is Armature.
+                # I change it a bit so it removed words before '|' and the '|' as well.
                 _name = _name.decode("utf-8")
-                if _name.startswith("Armature|"):
-                    _name = _name[9:]
+                if _name.__contains__("|"):
+                    indexed = _name.find("|")
+                    _name = _name[indexed+1:]
                 _name = _name.encode("utf-8")
 
                 animations.append((_astack_key, astack, _alayer_key, _name, _fstart, _fend))

--- a/blender_3_3_X/io_scene_fbx_custom/export_fbx_bin.py
+++ b/blender_3_3_X/io_scene_fbx_custom/export_fbx_bin.py
@@ -2066,10 +2066,12 @@ def fbx_animations(scene_data):
             # [Alessandro] Remove 'Armature|' animation name...
             if scene_data.settings.remove_ghost_armature_root_node_from_export:
                 _astack_key, astack, _alayer_key, _name, _fstart, _fend = anim
-
+                # [Choccy] The original function only worked when the armature name is Armature.
+                # I change it a bit so it removed words before '|' and the '|' as well.
                 _name = _name.decode("utf-8")
-                if _name.startswith("Armature|"):
-                    _name = _name[9:]
+                if _name.__contains__("|"):
+                    indexed = _name.find("|")
+                    _name = _name[indexed+1:]
                 _name = _name.encode("utf-8")
 
                 animations.append((_astack_key, astack, _alayer_key, _name, _fstart, _fend))

--- a/blender_3_4_X/io_scene_fbx_custom/export_fbx_bin.py
+++ b/blender_3_4_X/io_scene_fbx_custom/export_fbx_bin.py
@@ -2080,10 +2080,12 @@ def fbx_animations(scene_data):
             # [Alessandro] Remove 'Armature|' animation name...
             if scene_data.settings.remove_ghost_armature_root_node_from_export:
                 _astack_key, astack, _alayer_key, _name, _fstart, _fend = anim
-
+                # [Choccy] The original function only worked when the armature name is Armature.
+                # I change it a bit so it removed words before '|' and the '|' as well.
                 _name = _name.decode("utf-8")
-                if _name.startswith("Armature|"):
-                    _name = _name[9:]
+                if _name.__contains__("|"):
+                    indexed = _name.find("|")
+                    _name = _name[indexed+1:]
                 _name = _name.encode("utf-8")
 
                 animations.append((_astack_key, astack, _alayer_key, _name, _fstart, _fend))

--- a/blender_3_6_X/io_scene_fbx_custom/export_fbx_bin.py
+++ b/blender_3_6_X/io_scene_fbx_custom/export_fbx_bin.py
@@ -2320,10 +2320,12 @@ def fbx_animations(scene_data):
             # [Alessandro] Remove 'Armature|' animation name...
             if scene_data.settings.armature_nodetype == 'REMOVE_GHOST':
                 _astack_key, astack, _alayer_key, _name, _fstart, _fend = anim
-
+                # [Choccy] The original function only worked when the armature name is Armature.
+                # I change it a bit so it removed words before '|' and the '|' as well.
                 _name = _name.decode("utf-8")
-                if _name.startswith("Armature|"):
-                    _name = _name[9:]
+                if _name.__contains__("|"):
+                    indexed = _name.find("|")
+                    _name = _name[indexed+1:]
                 _name = _name.encode("utf-8")
 
                 animations.append((_astack_key, astack, _alayer_key, _name, _fstart, _fend))


### PR DESCRIPTION
First of all, thank you for providing this neat little blender addon to public. I have been using this addon to help me with modding unity game and it has been a tremendous tool, since I was dealing with hierarchy. 

Because of this, I want to improve the **"Armature|"** removal part. Currently, when exporting to FBX it only removes the prefix if it's named **"Armature|"**. I changed it so it can remove the prefix even without having the name be **"Armature|"**. I don't have a lot of coding knowledge, so the changes may not be ideal.